### PR TITLE
feat: Added back mock functionality

### DIFF
--- a/fhevm/precompiles.go
+++ b/fhevm/precompiles.go
@@ -78,7 +78,7 @@ func homeDir() string {
 func init() {
 	home := homeDir()
 
-	f, err := os.Open(home + "/.inco/config/node_config.toml")
+	f, err := os.Open(home + "/.ethermintd/config/node_config.toml")
 	if err != nil {
 		fmt.Println("failed to open node_config.toml file")
 		return

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.20
 require (
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c
+	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	golang.org/x/crypto v0.16.0
 )
 
 require (
+	github.com/naoina/go-stringutil v0.1.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,10 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
+github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
+github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
+github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=
+github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=


### PR DESCRIPTION
Config goes in ~/.inco/config/node_config.toml, as there is no easy way to pass in command line arguments to fhevm-go without modifying tendermint.
Config must look like this for mainnet:
`
[fhevm]

mock_ops_flag = false
`

And for devnet/testnet:
`
[fhevm]

mock_ops_flag = true
`