### PR TITLE
feat: Rename SgxPlaintext fields and add tests

### DIFF
--- a/fhevm/sgx_arithmetic.go
+++ b/fhevm/sgx_arithmetic.go
@@ -60,6 +60,9 @@ func doArithmeticOperation(op string, environment EVMEnvironment, caller common.
 	// A more efficient way would be to use binary.BigEndian.UintXX().
 	// However, that would require a switch case. We prefer for now to use
 	// big.Int as a one-liner that can handle variable-length bytes.
+	//
+	// Note that we do arithmetic operations on uint64, then we convert th
+	// result back to the FheUintType.
 	l := big.NewInt(0).SetBytes(lp.Plaintext).Uint64()
 	r := big.NewInt(0).SetBytes(rp.Plaintext).Uint64()
 

--- a/fhevm/sgx_arithmetic_test.go
+++ b/fhevm/sgx_arithmetic_test.go
@@ -1,0 +1,109 @@
+package fhevm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/zama-ai/fhevm-go/fhevm/tfhe"
+	"github.com/zama-ai/fhevm-go/sgx"
+)
+
+func TestSgxAddRun(t *testing.T) {
+	// SgxLibAdd(t, tfhe.FheUint4)
+	SgxLibAdd(t, tfhe.FheUint8)
+	// SgxLibAdd(t, tfhe.FheUint16)
+	// SgxLibAdd(t, tfhe.FheUint32)
+	// SgxLibAdd(t, tfhe.FheUint64)
+}
+
+func SgxLibAdd(t *testing.T, fheUintType tfhe.FheUintType) {
+	var lhs, rhs uint64
+	switch fheUintType {
+	case tfhe.FheUint4:
+		lhs = 2
+		rhs = 1
+	case tfhe.FheUint8:
+		lhs = 2
+		rhs = 1
+	case tfhe.FheUint16:
+		lhs = 4283
+		rhs = 1337
+	case tfhe.FheUint32:
+		lhs = 1333337
+		rhs = 133337
+	case tfhe.FheUint64:
+		lhs = 13333377777777777
+		rhs = 133377777777
+	}
+	expected := lhs + rhs
+	signature := "sgxAdd(uint256,uint256,bytes1)"
+	depth := 1
+	environment := newTestEVMEnvironment()
+	environment.depth = depth
+	addr := common.Address{}
+	readOnly := false
+	lhsCt, err := importSgxCiphertextToEVM(environment, depth, lhs, fheUintType)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	rhsCt, err := importSgxCiphertextToEVM(environment, depth, rhs, fheUintType)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	input := toLibPrecompileInput(signature, false, lhsCt.GetHash(), rhsCt.GetHash())
+	out, err := FheLibRun(environment, addr, addr, input, readOnly)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	res := getVerifiedCiphertextFromEVM(environment, common.BytesToHash(out))
+	if res == nil {
+		t.Fatalf("output ciphertext is not found in verifiedCiphertexts")
+	}
+	decryptedSgxPlaintext, err := sgx.FromTfheCiphertext(res.ciphertext)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if decryptedSgxPlaintext.Type != fheUintType {
+		t.Fatalf("incorrect fheUintType, expected=%s, got=%s", fheUintType, decryptedSgxPlaintext.Type)
+	}
+
+	var decryptedResult uint64
+	switch fheUintType {
+	case tfhe.FheUint4:
+		decryptedResult = uint64(decryptedSgxPlaintext.AsUint8())
+	case tfhe.FheUint8:
+		decryptedResult = uint64(decryptedSgxPlaintext.AsUint8())
+	case tfhe.FheUint16:
+		decryptedResult = uint64(decryptedSgxPlaintext.AsUint16())
+	case tfhe.FheUint32:
+		decryptedResult = uint64(decryptedSgxPlaintext.AsUint32())
+	case tfhe.FheUint64:
+		decryptedResult = decryptedSgxPlaintext.AsUint64()
+	}
+
+	if decryptedResult != expected {
+		t.Fatalf("incorrect result, expected=%d, got=%s", expected, decryptedSgxPlaintext)
+	}
+}
+
+func toSgxPlaintext(value uint64, typ tfhe.FheUintType) (sgx.SgxPlaintext, error) {
+	i := new(big.Int).SetUint64(value)
+	return sgx.NewSgxPlaintext(i.Bytes(), typ, common.Address{}), nil
+}
+
+func importSgxCiphertextToEVM(environment EVMEnvironment, depth int, value uint64, typ tfhe.FheUintType) (tfhe.TfheCiphertext, error) {
+	sgxPlaintext, err := toSgxPlaintext(value, typ)
+	if err != nil {
+		return tfhe.TfheCiphertext{}, err
+	}
+	ct, err := sgx.ToTfheCiphertext(sgxPlaintext)
+	if err != nil {
+		return tfhe.TfheCiphertext{}, err
+	}
+
+	importCiphertextToEVMAtDepth(environment, &ct, depth)
+	return ct, nil
+}

--- a/fhevm/sgx_arithmetic_test.go
+++ b/fhevm/sgx_arithmetic_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestSgxAddRun(t *testing.T) {
-	// SgxLibAdd(t, tfhe.FheUint4)
+	SgxLibAdd(t, tfhe.FheUint4)
 	SgxLibAdd(t, tfhe.FheUint8)
-	// SgxLibAdd(t, tfhe.FheUint16)
-	// SgxLibAdd(t, tfhe.FheUint32)
-	// SgxLibAdd(t, tfhe.FheUint64)
+	SgxLibAdd(t, tfhe.FheUint16)
+	SgxLibAdd(t, tfhe.FheUint32)
+	SgxLibAdd(t, tfhe.FheUint64)
 }
 
 func SgxLibAdd(t *testing.T, fheUintType tfhe.FheUintType) {
@@ -66,8 +66,8 @@ func SgxLibAdd(t *testing.T, fheUintType tfhe.FheUintType) {
 		t.Fatalf(err.Error())
 	}
 
-	if decryptedSgxPlaintext.Type != fheUintType {
-		t.Fatalf("incorrect fheUintType, expected=%s, got=%s", fheUintType, decryptedSgxPlaintext.Type)
+	if decryptedSgxPlaintext.FheUintType != fheUintType {
+		t.Fatalf("incorrect fheUintType, expected=%s, got=%s", fheUintType, decryptedSgxPlaintext.FheUintType)
 	}
 
 	var decryptedResult uint64
@@ -85,7 +85,7 @@ func SgxLibAdd(t *testing.T, fheUintType tfhe.FheUintType) {
 	}
 
 	if decryptedResult != expected {
-		t.Fatalf("incorrect result, expected=%d, got=%s", expected, decryptedSgxPlaintext)
+		t.Fatalf("incorrect result, expected=%d, got=%d", expected, decryptedResult)
 	}
 }
 

--- a/fhevm/sgx_arithmetic_test.go
+++ b/fhevm/sgx_arithmetic_test.go
@@ -52,7 +52,7 @@ func TestSgxSubRun(t *testing.T) {
 		{tfhe.FheUint64, 13333377777777777, 133377777777},
 	}
 	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("sgxAdd with %s", tc.typ), func(t *testing.T) {
+		t.Run(fmt.Sprintf("sgxSub with %s", tc.typ), func(t *testing.T) {
 			sgxArithmeticHelper(t, tc.typ, tc.lhs, tc.rhs, op, signature)
 		})
 	}
@@ -76,7 +76,7 @@ func TestSgxMulRun(t *testing.T) {
 		{tfhe.FheUint64, 137777, 17},
 	}
 	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("sgxAdd with %s", tc.typ), func(t *testing.T) {
+		t.Run(fmt.Sprintf("sgxMul with %s", tc.typ), func(t *testing.T) {
 			sgxArithmeticHelper(t, tc.typ, tc.lhs, tc.rhs, op, signature)
 		})
 	}

--- a/fhevm/sgx_crypto.go
+++ b/fhevm/sgx_crypto.go
@@ -80,7 +80,7 @@ func sgxDecryptRun(environment EVMEnvironment, caller common.Address, addr commo
 		return nil, err
 	}
 
-	plaintext := result.Plaintext
+	plaintext := result.Value
 
 	logger.Info("sgxDecrypt success", "plaintext", plaintext)
 

--- a/fhevm/sgx_crypto.go
+++ b/fhevm/sgx_crypto.go
@@ -28,7 +28,7 @@ func sgxEncryptRun(environment EVMEnvironment, caller common.Address, addr commo
 
 	sgxPlaintext := sgx.NewSgxPlaintext(input[0:32], encryptToType, caller)
 
-	ct, err := sgx.ToTfheCiphertext(sgxPlaintext)
+	ct, err := sgx.Encrypt(sgxPlaintext)
 
 	if err != nil {
 		logger.Error("sgxEncrypt failed", "err", err)
@@ -74,7 +74,7 @@ func sgxDecryptRun(environment EVMEnvironment, caller common.Address, addr commo
 		return bytes.Repeat([]byte{0xFF}, 32), nil
 	}
 
-	result, err := sgx.FromTfheCiphertext(ct.ciphertext)
+	result, err := sgx.Decrypt(ct.ciphertext)
 	if err != nil {
 		logger.Error("sgxDecrypt failed", "err", err)
 		return nil, err

--- a/fhevm/sgx_crypto.go
+++ b/fhevm/sgx_crypto.go
@@ -79,13 +79,12 @@ func sgxDecryptRun(environment EVMEnvironment, caller common.Address, addr commo
 		logger.Error("sgxDecrypt failed", "err", err)
 		return nil, err
 	}
-
 	plaintext := result.Value
 
 	logger.Info("sgxDecrypt success", "plaintext", plaintext)
 
 	// Always return a 32-byte big-endian integer.
 	ret := make([]byte, 32)
-	copy(ret, plaintext)
+	copy(ret[32-len(plaintext):], plaintext)
 	return ret, nil
 }

--- a/fhevm/sgx_crypto_test.go
+++ b/fhevm/sgx_crypto_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/zama-ai/fhevm-go/fhevm/tfhe"
-	"github.com/zama-ai/fhevm-go/sgx"
 	"pgregory.net/rapid"
 )
 
@@ -29,7 +28,7 @@ func TestSgxDecryptRun(t *testing.T) {
 			environment.depth = depth
 			addr := common.Address{}
 			readOnly := false
-			ct, err := importSgxCiphertextToEVM(environment, depth, tc.expected, tc.typ)
+			ct, err := importSgxPlaintextToEVM(environment, depth, tc.expected, tc.typ)
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -39,20 +38,8 @@ func TestSgxDecryptRun(t *testing.T) {
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
-			res := getVerifiedCiphertextFromEVM(environment, common.BytesToHash(out))
-			if res == nil {
-				t.Fatalf("output ciphertext is not found in verifiedCiphertexts")
-			}
-			sgxPlaintext, err := sgx.Decrypt(res.ciphertext)
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
 
-			if sgxPlaintext.FheUintType != tfhe.FheUint8 {
-				t.Fatalf("incorrect fheUintType, expected=%s, got=%s", tc.typ, sgxPlaintext.FheUintType)
-			}
-
-			result := new(big.Int).SetBytes(sgxPlaintext.Value).Uint64()
+			result := new(big.Int).SetBytes(out).Uint64()
 			if result != tc.expected {
 				t.Fatalf("incorrect result, expected=%d, got=%d", tc.expected, result)
 			}

--- a/fhevm/sgx_crypto_test.go
+++ b/fhevm/sgx_crypto_test.go
@@ -1,0 +1,61 @@
+package fhevm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/zama-ai/fhevm-go/fhevm/tfhe"
+	"github.com/zama-ai/fhevm-go/sgx"
+	"pgregory.net/rapid"
+)
+
+func TestSgxDecryptRun(t *testing.T) {
+	signature := "sgxDecrypt(uint256)"
+	rapid.Check(t, func(t *rapid.T) {
+		testcases := []struct {
+			typ      tfhe.FheUintType
+			expected uint64
+		}{
+			{tfhe.FheUint4, uint64(rapid.Uint8().Draw(t, "expected"))},
+			{tfhe.FheUint8, uint64(rapid.Uint8().Draw(t, "expected"))},
+			{tfhe.FheUint16, uint64(rapid.Uint16().Draw(t, "expected"))},
+			{tfhe.FheUint32, uint64(rapid.Uint32().Draw(t, "expected"))},
+			{tfhe.FheUint64, rapid.Uint64().Draw(t, "expected")},
+		}
+		for _, tc := range testcases {
+			depth := 1
+			environment := newTestEVMEnvironment()
+			environment.depth = depth
+			addr := common.Address{}
+			readOnly := false
+			ct, err := importSgxCiphertextToEVM(environment, depth, tc.expected, tc.typ)
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			input := toLibPrecompileInput(signature, false, ct.GetHash())
+			out, err := FheLibRun(environment, addr, addr, input, readOnly)
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			res := getVerifiedCiphertextFromEVM(environment, common.BytesToHash(out))
+			if res == nil {
+				t.Fatalf("output ciphertext is not found in verifiedCiphertexts")
+			}
+			sgxPlaintext, err := sgx.Decrypt(res.ciphertext)
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			if sgxPlaintext.FheUintType != tfhe.FheUint8 {
+				t.Fatalf("incorrect fheUintType, expected=%s, got=%s", tc.typ, sgxPlaintext.FheUintType)
+			}
+
+			result := new(big.Int).SetBytes(sgxPlaintext.Value).Uint64()
+			if result != tc.expected {
+				t.Fatalf("incorrect result, expected=%d, got=%d", tc.expected, result)
+			}
+		}
+	})
+}

--- a/sgx/sgx_mock.go
+++ b/sgx/sgx_mock.go
@@ -78,7 +78,7 @@ func (sp SgxPlaintext) AsUint64() uint64 {
 	return binary.BigEndian.Uint64(sp.Value)
 }
 
-func ToTfheCiphertext(sgxCt SgxPlaintext) (tfhe.TfheCiphertext, error) {
+func Encrypt(sgxCt SgxPlaintext) (tfhe.TfheCiphertext, error) {
 	// Encode the SgxPlaintext struct as a byte array using JSON.
 	// This will be used as the plaintext for the ECIES encryption.
 	//
@@ -102,19 +102,19 @@ func ToTfheCiphertext(sgxCt SgxPlaintext) (tfhe.TfheCiphertext, error) {
 	}, nil
 }
 
-func FromTfheCiphertext(ct *tfhe.TfheCiphertext) (SgxPlaintext, error) {
+func Decrypt(ct *tfhe.TfheCiphertext) (SgxPlaintext, error) {
 	// Decrypt the ciphertext using the private key.
-	plaintext, err := key.Decrypt(ct.Serialization, nil, nil)
+	plaintextBz, err := key.Decrypt(ct.Serialization, nil, nil)
 	if err != nil {
 		return SgxPlaintext{}, err
 	}
 
-	// Decode the plaintext into a SgxPlaintext struct.
-	var sgxCt SgxPlaintext
-	err = json.Unmarshal(plaintext, &sgxCt)
+	// Decode the plaintext bytes into a SgxPlaintext struct.
+	var plaintext SgxPlaintext
+	err = json.Unmarshal(plaintextBz, &plaintext)
 	if err != nil {
 		return SgxPlaintext{}, err
 	}
 
-	return sgxCt, nil
+	return plaintext, nil
 }

--- a/sgx/sgx_mock.go
+++ b/sgx/sgx_mock.go
@@ -3,7 +3,9 @@ package sgx
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/gob"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -37,6 +39,42 @@ func NewSgxPlaintext(plaintext []byte, fheType tfhe.FheUintType, address common.
 		fheType,
 		address,
 	}
+}
+
+// AsUint8 returns the plaintext as a uint8.
+func (sp SgxPlaintext) AsUint8() uint8 {
+	if sp.Type != tfhe.FheUint4 && sp.Type != tfhe.FheUint8 {
+		panic(fmt.Sprintf("Expected FheUint4 or FheUint8, got %s", sp.Type))
+	}
+
+	return sp.Plaintext[0]
+}
+
+// AsUint16 returns the plaintext as a uint16.
+func (sp SgxPlaintext) AsUint16() uint16 {
+	if sp.Type != tfhe.FheUint16 {
+		panic(fmt.Sprintf("Expected FheUint16, got %s", sp.Type))
+	}
+
+	return binary.BigEndian.Uint16(sp.Plaintext)
+}
+
+// AsUint32 returns the plaintext as a uint32.
+func (sp SgxPlaintext) AsUint32() uint32 {
+	if sp.Type != tfhe.FheUint32 {
+		panic(fmt.Sprintf("Expected FheUint32, got %s", sp.Type))
+	}
+
+	return binary.BigEndian.Uint32(sp.Plaintext)
+}
+
+// AsUint64 returns the plaintext as a uint64.
+func (sp SgxPlaintext) AsUint64() uint64 {
+	if sp.Type != tfhe.FheUint64 {
+		panic(fmt.Sprintf("expected FheUint64, got %s", sp.Type))
+	}
+
+	return binary.BigEndian.Uint64(sp.Plaintext)
 }
 
 func ToTfheCiphertext(sgxCt SgxPlaintext) (tfhe.TfheCiphertext, error) {

--- a/sgx/sgx_mock.go
+++ b/sgx/sgx_mock.go
@@ -116,21 +116,5 @@ func FromTfheCiphertext(ct *tfhe.TfheCiphertext) (SgxPlaintext, error) {
 		return SgxPlaintext{}, err
 	}
 
-	// Update the Value field to have the minimum length.
-	switch sgxCt.FheUintType {
-	case tfhe.FheUint4:
-		sgxCt.Value = sgxCt.Value[:1]
-	case tfhe.FheUint8:
-		sgxCt.Value = sgxCt.Value[:1]
-	case tfhe.FheUint16:
-		sgxCt.Value = sgxCt.Value[:2]
-	case tfhe.FheUint32:
-		sgxCt.Value = sgxCt.Value[:4]
-	case tfhe.FheUint64:
-		sgxCt.Value = sgxCt.Value[:8]
-	default:
-		return SgxPlaintext{}, fmt.Errorf("unsupported FheUintType: %s", sgxCt.FheUintType)
-	}
-
 	return sgxCt, nil
 }

--- a/sgx/sgx_mock_test.go
+++ b/sgx/sgx_mock_test.go
@@ -25,17 +25,43 @@ func TestRoundTrip(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		a := sgxPlaintextGen.Draw(t, "a")
 
-		// To -> From round trip
-		b, err := sgx.ToTfheCiphertext(a)
+		// Encrypt -> Decrypt round trip
+		b, err := sgx.Encrypt(a)
 		if err != nil {
 			t.Fatal(err)
 		}
-		c, err := sgx.FromTfheCiphertext(&b)
+		c, err := sgx.Decrypt(&b)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !compareSgxPlaintexts(a, c) {
 			t.Fatalf("expected %v, got %v", a, c)
+		}
+	})
+}
+
+func TestUniqueCiphertexts(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		a := sgxPlaintextGen.Draw(t, "a")
+
+		// Encrypt twice the same plaintext
+		b, err := sgx.Encrypt(a)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := sgx.Encrypt(a)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Make sure the ciphertexts are different
+		if bytes.Equal(b.Serialization, c.Serialization) {
+			t.Fatalf("expected different ciphertexts, got %v", b)
+		}
+
+		// Make sure the hashes (handles) are different
+		if bytes.Equal(b.GetHash().Bytes(), c.GetHash().Bytes()) {
+			t.Fatalf("expected different hashes, got %v", b.GetHash())
 		}
 	})
 }

--- a/sgx/sgx_mock_test.go
+++ b/sgx/sgx_mock_test.go
@@ -18,7 +18,7 @@ var sgxPlaintextGen *rapid.Generator[sgx.SgxPlaintext] = rapid.Custom(func(t *ra
 })
 
 func compareSgxPlaintexts(a, b sgx.SgxPlaintext) bool {
-	return bytes.Equal(a.Plaintext, b.Plaintext) && a.Type == b.Type && a.Address == b.Address
+	return bytes.Equal(a.Value, b.Value) && a.FheUintType == b.FheUintType && a.Address == b.Address
 }
 
 func TestRoundTrip(t *testing.T) {


### PR DESCRIPTION
ref: https://github.com/Inco-fhevm/inco-monorepo/issues/6

- Rename `sgx.{To,From}TfheCiphertext` to `sgx.{Decrypt,Encrypt}`
- Add tests for sgxDecrypt, sgxAdd, sgxSub, sgxMul
- Fix some bugs that were found with tests