### PR TITLE
fix: bitwise operations for uint4 type

### DIFF
--- a/fhevm/tee_bit.go
+++ b/fhevm/tee_bit.go
@@ -14,7 +14,7 @@ func teeShlRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 		// There isn't bitwise shift operation between ebool. So it doesn't include case 0.
 		case tfhe.FheUint4:
 			a1, b1 := uint8(a), uint8(b)%4
-			return uint64(a1 << b1), nil
+			return uint64(a1<<b1) & 0x0F, nil
 		case tfhe.FheUint8:
 			a1, b1 := uint8(a), uint8(b)%8
 			return uint64(a1 << b1), nil
@@ -66,7 +66,7 @@ func teeRotlRun(environment EVMEnvironment, caller common.Address, addr common.A
 		// There isn't bitwise shift operation between ebool. So it doesn't include case 0.
 		case tfhe.FheUint4:
 			a1, b1 := uint8(a), uint8(b)%4
-			return uint64((a1 << b1) | (a1 >> (uint8(4) - b1))), nil
+			return uint64((a1<<b1)|(a1>>(uint8(4)-b1))) & 0x0F, nil
 		case tfhe.FheUint8:
 			a1, b1 := uint8(a), uint8(b)%8
 			return uint64((a1 << b1) | (a1 >> (uint8(8) - b1))), nil
@@ -94,7 +94,7 @@ func teeRotrRun(environment EVMEnvironment, caller common.Address, addr common.A
 		// There isn't bitwise shift operation between ebool. So it doesn't include case 0.
 		case tfhe.FheUint4:
 			a1, b1 := uint8(a), uint8(b)%4
-			return uint64((a1 >> b1) | (a1 << (uint8(4) - b1))), nil
+			return uint64((a1>>b1)|(a1<<(uint8(4)-b1))) & 0x0F, nil
 		case tfhe.FheUint8:
 			a1, b1 := uint8(a), uint8(b)%8
 			return uint64((a1 >> b1) | (a1 << (uint8(8) - b1))), nil

--- a/fhevm/tee_bit_test.go
+++ b/fhevm/tee_bit_test.go
@@ -88,7 +88,7 @@ func TestTeeRotrRun(t *testing.T) {
 		rhs      uint64
 		expected uint64
 	}{
-		{tfhe.FheUint4, 2, 1, 17},
+		{tfhe.FheUint4, 2, 1, 1},
 		{tfhe.FheUint8, 4, 2, 1},
 		{tfhe.FheUint16, 4283, 3, 25111},
 		{tfhe.FheUint32, 1333337, 10, 373294358},
@@ -186,7 +186,7 @@ func TestTeeNegRun(t *testing.T) {
 		chs      uint64
 		expected uint64
 	}{
-		{tfhe.FheUint4, 2, 254},
+		{tfhe.FheUint4, 2, 14},
 		{tfhe.FheUint8, 2, 254},
 		{tfhe.FheUint16, 4283, 61253},
 		{tfhe.FheUint32, 1333337, 4293633959},
@@ -207,7 +207,7 @@ func TestTeeNotRun(t *testing.T) {
 		chs      uint64
 		expected uint64
 	}{
-		{tfhe.FheUint4, 2, 253},
+		{tfhe.FheUint4, 2, 13},
 		{tfhe.FheUint8, 2, 253},
 		{tfhe.FheUint16, 4283, 61252},
 		{tfhe.FheUint32, 1333337, 4293633958},

--- a/fhevm/tee_crypto_test.go
+++ b/fhevm/tee_crypto_test.go
@@ -16,7 +16,7 @@ func TestTeeDecryptRun(t *testing.T) {
 			typ      tfhe.FheUintType
 			expected uint64
 		}{
-			{tfhe.FheUint4, uint64(rapid.Uint8().Draw(t, "expected"))},
+			{tfhe.FheUint4, uint64(rapid.Uint8Range(0, 15).Draw(t, "expected"))},
 			{tfhe.FheUint8, uint64(rapid.Uint8().Draw(t, "expected"))},
 			{tfhe.FheUint16, uint64(rapid.Uint16().Draw(t, "expected"))},
 			{tfhe.FheUint32, uint64(rapid.Uint32().Draw(t, "expected"))},


### PR DESCRIPTION
Some bitwise operations for euint4 types were treated as if they were euint8 types.
For example, for uint4 vaule of 2 (suppose that it is `a`), `a << 3` resulted in 16 instead of 0 because we didn't care if the result gets overflowed. In this PR, I fixed this.

And if this PR is merged into `main`, the unit tests which failed after https://github.com/Inco-fhevm/fhevm-go/pull/26 would pass. So it needs to be merged after https://github.com/Inco-fhevm/fhevm-go/pull/26